### PR TITLE
Set SANE_CONFIG_DIR

### DIFF
--- a/org.gnome.SimpleScan.json
+++ b/org.gnome.SimpleScan.json
@@ -12,7 +12,8 @@
         "--socket=wayland",
         "--device=all",
         "--share=network",
-        "--system-talk-name=org.freedesktop.Avahi"
+        "--system-talk-name=org.freedesktop.Avahi",
+	"--env=SANE_CONFIG_DIR=/app/etc/sane.d"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
We need to set SANE_CONFIG_DIR to /app/etc/sane.d to allow SANE to find the configuration directory which on this flatpak is not in the default path (/etc/sane.d)