### PR TITLE
Activate escl sane backend

### DIFF
--- a/org.gnome.SimpleScan.json
+++ b/org.gnome.SimpleScan.json
@@ -50,22 +50,6 @@
             ]
         },
         {
-            "name": "sane-backends",
-            "buildsystem": "autotools",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.com/sane-project/backends.git",
-                    "commit": "7088afe04dc83395af599b6c224b020a142e64d8",
-                    "tag": "1.3.0",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^([\\d.]+)$"
-                    }
-                }
-            ]
-        },
-        {
             "name": "net-snmp",
             "no-parallel-make": true,
             "config-opts": [
@@ -147,6 +131,22 @@
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "sane-backends",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.com/sane-project/backends.git",
+                    "commit": "7088afe04dc83395af599b6c224b020a142e64d8",
+                    "tag": "1.3.0",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
                     }
                 }
             ]


### PR DESCRIPTION
Currently, the [SANE backend for eSCL protocol scanners](https://manpages.debian.org/unstable/libsane-common/sane-escl.5.en.html) does not seem enabled.  
Building sane-backends **after** avahi seems to active it.

I cannot test, but with this pull request, a new `/app/etc/sane.d/escl.conf` file is created in the SimpleScan flatpak.  
```
flatpak run --command=ls  org.gnome.SimpleScan /app/etc/sane.d/
```