### PR TITLE
Add data checkers for sources

### DIFF
--- a/org.gnome.SimpleScan.json
+++ b/org.gnome.SimpleScan.json
@@ -208,7 +208,13 @@
                 {
                     "type": "archive",
                     "url": "https://downloads.sourceforge.net/sourceforge/hplip/hplip-3.23.12.tar.gz",
-                    "sha256": "a76c2ac8deb31ddb5f0da31398d25ac57440928a0692dcb060a48daa718e69ed"
+                    "sha256": "a76c2ac8deb31ddb5f0da31398d25ac57440928a0692dcb060a48daa718e69ed",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1327,
+                        "stable-only": true,
+                        "url-template": "https://downloads.sourceforge.net/sourceforge/hplip/hplip-$version.tar.gz"
+                    }
                 },
                 {
                     "type": "shell",

--- a/org.gnome.SimpleScan.json
+++ b/org.gnome.SimpleScan.json
@@ -88,7 +88,13 @@
                 {
                     "type": "archive",
                     "url": "https://downloads.sourceforge.net/net-snmp/net-snmp-5.9.4.tar.gz",
-                    "sha256": "8b4de01391e74e3c7014beb43961a2d6d6fa03acc34280b9585f4930745b0544"
+                    "sha256": "8b4de01391e74e3c7014beb43961a2d6d6fa03acc34280b9585f4930745b0544",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 2062,
+                        "stable-only": true,
+                        "url-template": "https://downloads.sourceforge.net/net-snmp/net-snmp-$version.tar.gz"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
- Add [anitya checker for net-snmp](https://release-monitoring.org/project/2062/)
- Add [anitya checker for hplip](https://release-monitoring.org/project/1327/)

In pull request #23, I forgot to add `x-checker-data` sections.
I use [anitya](https://github.com/flathub-infra/flatpak-external-data-checker?tab=readme-ov-file#anitya-release-monitoring-checker) checkers because they allow to choose stable version for sources.