### PR TITLE
downgrade gnome runtime to 48, due to a bug in gdk-pixbuf that does not allow saving

### DIFF
--- a/org.gnome.SimpleScan.json
+++ b/org.gnome.SimpleScan.json
@@ -1,7 +1,7 @@
 {
     "id": "org.gnome.SimpleScan",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "simple-scan",
     "finish-args": [
@@ -28,6 +28,7 @@
         "*.a"
     ],
     "modules": [
+        "shared-modules/libusb/libusb.json",
         {
             "name": "libgusb",
             "buildsystem": "meson",


### PR DESCRIPTION
Can not save file, when you try to save a pdf you receive this error "unhandled key while saving: x-dpi"

all detail there https://github.com/flathub/org.gnome.SimpleScan/issues/52